### PR TITLE
Fix invalid domain error

### DIFF
--- a/cfn-templates/Lab0-baseline-setup.yml
+++ b/cfn-templates/Lab0-baseline-setup.yml
@@ -156,7 +156,7 @@ Resources:
   NATGateway1EIP:
     Type: AWS::EC2::EIP
     Properties:
-      Domain: Vpc
+      Domain: vpc
 
   NATGateway1:
     Type: AWS::EC2::NatGateway


### PR DESCRIPTION
The EIP domain should be lowercase `vpc`. 
