### PR TITLE
Fix invalid syntax

### DIFF
--- a/cfn-templates/Lab0-baseline-setup.yml
+++ b/cfn-templates/Lab0-baseline-setup.yml
@@ -123,7 +123,9 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
     Type: AWS::EC2::Route
-    DependsOn: PublicRouteTable
+    DependsOn:
+      - PublicRouteTable
+      - GatewayToInternet
 
   PubSubnet1RTAssoc:
     Properties:

--- a/cfn-templates/Lab0-baseline-setup.yml
+++ b/cfn-templates/Lab0-baseline-setup.yml
@@ -176,7 +176,7 @@ Resources:
     Properties:
       AllocationId: !GetAtt NATGateway1EIP.AllocationId
       SubnetId: !Ref PubSubnet1
-    DependsOn:PubSubnet1
+    DependsOn: PubSubnet1
 
   PrivateRoute1:
     Properties:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

It seems that PR #37 (commit 6726084) introduced a couple of regressions in `Lab0-baseline-setup.yml`. This PR fixes them:

* There seems to be some invalid syntax, breaking the template.
* PR #37 added some `DependsOn` statements, but `PublicRoute` should depend not only on the route table but on the Internet Gateway attachment too, otherwise the stack creation fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
