### PR TITLE
Replaced AMIs FindInMap with SSM Param Store for recommended ECS Opti…

### DIFF
--- a/cfn-templates/Lab1-add-ondemand-asg-to-cluster.yml
+++ b/cfn-templates/Lab1-add-ondemand-asg-to-cluster.yml
@@ -9,30 +9,10 @@ Parameters:
     Type: String
     Description: "Name of the ECS cluster you created earlier"
     Default: catsndogsECScluster
-Mappings:
-  AWSRegionToAMI:
-    us-east-1:
-      AMIID: ami-9eb4b1e5
-    us-east-2:
-      AMIID: ami-1c002379
-    us-west-1:
-      AMIID: ami-4a2c192a
-    us-west-2:
-      AMIID: ami-1d668865
-    eu-central-1:
-      AMIID: ami-0460cb6b
-    eu-west-1:
-      AMIID: ami-8fcc32f6
-    eu-west-2:
-      AMIID: ami-cb1101af
-    ap-northeast-1:
-      AMIID: ami-b743bed1
-    ap-southeast-2:
-      AMIID: ami-c1a6bda2
-    ap-southeast-1:
-      AMIID: ami-9d1f7efe
-    ca-central-1:
-      AMIID: ami-b677c9d2
+  ECSAMI:
+    Description: AMI ID
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 Resources:
   ASGSNSTopic:
     Type: "AWS::SNS::Topic"
@@ -71,7 +51,7 @@ Resources:
 
                     ', echo ECS_CLUSTER=, !Ref 'ECSCluster', ' >> /etc/ecs/ecs.config']]
     Properties:
-      ImageId: !FindInMap [AWSRegionToAMI, !Ref 'AWS::Region', AMIID]
+      ImageId: !Ref ECSAMI
       InstanceType: t2.medium
       UserData: !Base64
         Fn::Join:


### PR DESCRIPTION
…mized AMI so that the latest ECS AMI for the region is used instead. The one in the AMI FindInMap had an outdated ECS Agent. Now, no matter what region you deploy to, the latest ECS optimized AMI will be dynamically set and used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
